### PR TITLE
Filter non draft surveys

### DIFF
--- a/src/main/java/sysc4806/project24/mini_survey_monkey/WebMvcConfig.java
+++ b/src/main/java/sysc4806/project24/mini_survey_monkey/WebMvcConfig.java
@@ -1,0 +1,21 @@
+package sysc4806.project24.mini_survey_monkey;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import sysc4806.project24.mini_survey_monkey.interceptors.DraftSurveyInterceptor;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final DraftSurveyInterceptor surveyStateInterceptor;
+
+    public WebMvcConfig(DraftSurveyInterceptor surveyStateInterceptor) {
+        this.surveyStateInterceptor = surveyStateInterceptor;
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(surveyStateInterceptor).addPathPatterns("/**/create/**");
+    }
+}

--- a/src/main/java/sysc4806/project24/mini_survey_monkey/WebMvcConfig.java
+++ b/src/main/java/sysc4806/project24/mini_survey_monkey/WebMvcConfig.java
@@ -16,9 +16,9 @@ public class WebMvcConfig implements WebMvcConfigurer {
 
     public WebMvcConfig(SurveyStateInterceptor draftSurveyInterceptor, SurveyStateInterceptor nonDraftSurveyInterceptor) {
         this.draftSurveyInterceptor = draftSurveyInterceptor;
-        draftSurveyInterceptor.setStateToFilter(List.of(State.DRAFT));
+        draftSurveyInterceptor.setStatesToFilterOut(List.of(State.DRAFT));
 
-        nonDraftSurveyInterceptor.setStateToFilter(List.of(State.OPEN, State.CLOSED));
+        nonDraftSurveyInterceptor.setStatesToFilterOut(List.of(State.OPEN, State.CLOSED));
         this.nonDraftSurveyInterceptor = nonDraftSurveyInterceptor;
     }
 

--- a/src/main/java/sysc4806/project24/mini_survey_monkey/WebMvcConfig.java
+++ b/src/main/java/sysc4806/project24/mini_survey_monkey/WebMvcConfig.java
@@ -24,8 +24,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(draftSurveyInterceptor).addPathPatterns("/**/create/**");
-
-//        registry.addInterceptor(nonDraftSurveyInterceptor).addPathPatterns("/**/survey/**"); TODO: Uncomment when survey endpoints are added
+        registry.addInterceptor(nonDraftSurveyInterceptor).addPathPatterns("/**/create/**");
+//        registry.addInterceptor(draftSurveyInterceptor).addPathPatterns("/**/survey/**"); TODO: Uncomment when survey endpoints are added
     }
 }

--- a/src/main/java/sysc4806/project24/mini_survey_monkey/WebMvcConfig.java
+++ b/src/main/java/sysc4806/project24/mini_survey_monkey/WebMvcConfig.java
@@ -3,19 +3,29 @@ package sysc4806.project24.mini_survey_monkey;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import sysc4806.project24.mini_survey_monkey.interceptors.DraftSurveyInterceptor;
+import sysc4806.project24.mini_survey_monkey.interceptors.SurveyStateInterceptor;
+import sysc4806.project24.mini_survey_monkey.models.State;
+
+import java.util.List;
 
 @Configuration
 public class WebMvcConfig implements WebMvcConfigurer {
 
-    private final DraftSurveyInterceptor surveyStateInterceptor;
+    private final SurveyStateInterceptor draftSurveyInterceptor;
+    private final SurveyStateInterceptor nonDraftSurveyInterceptor;
 
-    public WebMvcConfig(DraftSurveyInterceptor surveyStateInterceptor) {
-        this.surveyStateInterceptor = surveyStateInterceptor;
+    public WebMvcConfig(SurveyStateInterceptor draftSurveyInterceptor, SurveyStateInterceptor nonDraftSurveyInterceptor) {
+        this.draftSurveyInterceptor = draftSurveyInterceptor;
+        draftSurveyInterceptor.setStateToFilter(List.of(State.DRAFT));
+
+        nonDraftSurveyInterceptor.setStateToFilter(List.of(State.OPEN, State.CLOSED));
+        this.nonDraftSurveyInterceptor = nonDraftSurveyInterceptor;
     }
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(surveyStateInterceptor).addPathPatterns("/**/create/**");
+        registry.addInterceptor(draftSurveyInterceptor).addPathPatterns("/**/create/**");
+
+//        registry.addInterceptor(nonDraftSurveyInterceptor).addPathPatterns("/**/survey/**"); TODO: Uncomment when survey endpoints are added
     }
 }

--- a/src/main/java/sysc4806/project24/mini_survey_monkey/interceptors/DraftSurveyInterceptor.java
+++ b/src/main/java/sysc4806/project24/mini_survey_monkey/interceptors/DraftSurveyInterceptor.java
@@ -1,0 +1,37 @@
+package sysc4806.project24.mini_survey_monkey.interceptors;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+import sysc4806.project24.mini_survey_monkey.models.State;
+import sysc4806.project24.mini_survey_monkey.models.Survey;
+import sysc4806.project24.mini_survey_monkey.repositories.SurveyRepository;
+
+@Component
+public class DraftSurveyInterceptor implements HandlerInterceptor {
+
+    private final SurveyRepository surveyRepository;
+
+    public DraftSurveyInterceptor(SurveyRepository surveyRepository) {
+        this.surveyRepository = surveyRepository;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        Object surveyIDAttribute = request.getAttribute("surveyID");
+        if (surveyIDAttribute == null) {
+            return true;
+        }
+
+        int surveyID = Integer.parseInt(surveyIDAttribute.toString());
+        Survey survey = surveyRepository.findById(surveyID);
+
+        // Filter out non-draft surveys
+        if (survey != null && survey.getState() != State.DRAFT) {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Survey is " + survey.getState().toString().toLowerCase());
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/sysc4806/project24/mini_survey_monkey/interceptors/SurveyStateInterceptor.java
+++ b/src/main/java/sysc4806/project24/mini_survey_monkey/interceptors/SurveyStateInterceptor.java
@@ -8,12 +8,16 @@ import sysc4806.project24.mini_survey_monkey.models.State;
 import sysc4806.project24.mini_survey_monkey.models.Survey;
 import sysc4806.project24.mini_survey_monkey.repositories.SurveyRepository;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Component
-public class DraftSurveyInterceptor implements HandlerInterceptor {
+public class SurveyStateInterceptor implements HandlerInterceptor {
 
     private final SurveyRepository surveyRepository;
+    private List<State> stateToFilter = new ArrayList<>();
 
-    public DraftSurveyInterceptor(SurveyRepository surveyRepository) {
+    public SurveyStateInterceptor(SurveyRepository surveyRepository) {
         this.surveyRepository = surveyRepository;
     }
 
@@ -28,10 +32,19 @@ public class DraftSurveyInterceptor implements HandlerInterceptor {
         Survey survey = surveyRepository.findById(surveyID);
 
         // Filter out non-draft surveys
-        if (survey != null && survey.getState() != State.DRAFT) {
-            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Survey is " + survey.getState().toString().toLowerCase());
+        if (survey != null && stateToFilter.contains(survey.getState())) {
+
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Cannot be visited while survey is in state: " + survey.getState().toString());
             return false;
         }
         return true;
+    }
+
+    public List<State> getStateToFilter() {
+        return stateToFilter;
+    }
+
+    public void setStateToFilter(List<State> stateToFilter) {
+        this.stateToFilter = stateToFilter;
     }
 }


### PR DESCRIPTION
# Description
<!-- What does this pull request do? -->
This adds request filters so that we can block users from accessing:
- `/create/{surveyID}` endpoints when the survey is **open** or **closed**
- View/Analysis endpoints when the survey is a **draft**

# Checklist
**I've added tests**
- [ ] Yes
<!-- If no, describe why -->
- [x] No. I'm going to add tests for opening and closing surveys which will verify this.

**I've updated the DB schema and UML diagram**
- [ ] Yes
- [x] No
