### PR TITLE
Unique sharing link for each survey

### DIFF
--- a/src/main/java/sysc4806/project24/mini_survey_monkey/WebMvcConfig.java
+++ b/src/main/java/sysc4806/project24/mini_survey_monkey/WebMvcConfig.java
@@ -5,6 +5,7 @@ import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import sysc4806.project24.mini_survey_monkey.interceptors.CollectInterceptor;
 import sysc4806.project24.mini_survey_monkey.interceptors.CreateInterceptor;
+import sysc4806.project24.mini_survey_monkey.interceptors.ResponseInterceptor;
 import sysc4806.project24.mini_survey_monkey.interceptors.SummaryInterceptor;
 
 @Configuration
@@ -12,11 +13,13 @@ public class WebMvcConfig implements WebMvcConfigurer {
 
     private final CreateInterceptor createInterceptor;
     private final CollectInterceptor collectInterceptor;
+    private final ResponseInterceptor responseInterceptor;
     private final SummaryInterceptor summaryInterceptor;
 
-    public WebMvcConfig(CreateInterceptor createInterceptor, CollectInterceptor collectInterceptor, SummaryInterceptor summaryInterceptor) {
+    public WebMvcConfig(CreateInterceptor createInterceptor, CollectInterceptor collectInterceptor, ResponseInterceptor responseInterceptor, SummaryInterceptor summaryInterceptor) {
         this.createInterceptor = createInterceptor;
         this.collectInterceptor = collectInterceptor;
+        this.responseInterceptor = responseInterceptor;
         this.summaryInterceptor = summaryInterceptor;
     }
 
@@ -24,6 +27,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(createInterceptor).addPathPatterns("/**/create/**");
         registry.addInterceptor(collectInterceptor).addPathPatterns("/**/collect/**");
+        registry.addInterceptor(responseInterceptor).addPathPatterns("/**/r/**");
         registry.addInterceptor(summaryInterceptor).addPathPatterns("/**/summary/**");
     }
 }

--- a/src/main/java/sysc4806/project24/mini_survey_monkey/controllers/CollectController.java
+++ b/src/main/java/sysc4806/project24/mini_survey_monkey/controllers/CollectController.java
@@ -25,15 +25,16 @@ public class CollectController {
         int serverPort = request.getServerPort(); // port number
         String contextPath = request.getContextPath(); // app context path, if any
 
+        Survey survey = surveyRepository.findById(surveyID);
+
         // Construct the full URL for /r/1
         String fullUrl;
         if (serverPort == 80 || serverPort == 443) {
-            fullUrl = scheme + "://" + serverName + contextPath + "/r/1";
+            fullUrl = scheme + "://" + serverName + contextPath + "/r/" + surveyID;
         } else {
-            fullUrl = scheme + "://" + serverName + ":" + serverPort + contextPath + "/r/1";
+            fullUrl = scheme + "://" + serverName + ":" + serverPort + contextPath + "/r/" + surveyID;
         }
 
-        Survey survey = surveyRepository.findById(surveyID);
 
         survey.setSharingLink(fullUrl);
         model.addAttribute("survey", survey);

--- a/src/main/java/sysc4806/project24/mini_survey_monkey/controllers/RespondController.java
+++ b/src/main/java/sysc4806/project24/mini_survey_monkey/controllers/RespondController.java
@@ -1,19 +1,26 @@
 package sysc4806.project24.mini_survey_monkey.controllers;
 
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import sysc4806.project24.mini_survey_monkey.models.Survey;
 import sysc4806.project24.mini_survey_monkey.repositories.SurveyRepository;
 
 @Controller
 public class RespondController {
+
     private final SurveyRepository surveyRepository;
 
     public RespondController(SurveyRepository surveyRepository) {
         this.surveyRepository = surveyRepository;
     }
 
-    @GetMapping("/r/1")
-    public String respond() {
+    @GetMapping("/r/{surveyID}")
+    public String respond(@PathVariable("surveyID") int surveyID, Model model) {
+        Survey survey = surveyRepository.findById(surveyID);
+        model.addAttribute("survey", survey);
 
         return "respond";
     }

--- a/src/main/java/sysc4806/project24/mini_survey_monkey/interceptors/ResponseInterceptor.java
+++ b/src/main/java/sysc4806/project24/mini_survey_monkey/interceptors/ResponseInterceptor.java
@@ -1,0 +1,24 @@
+package sysc4806.project24.mini_survey_monkey.interceptors;
+
+import org.springframework.stereotype.Component;
+import sysc4806.project24.mini_survey_monkey.models.State;
+import sysc4806.project24.mini_survey_monkey.repositories.SurveyRepository;
+
+import java.util.HashSet;
+
+import org.springframework.stereotype.Component;
+import sysc4806.project24.mini_survey_monkey.models.State;
+import sysc4806.project24.mini_survey_monkey.repositories.SurveyRepository;
+
+import java.util.HashSet;
+
+@Component
+public class ResponseInterceptor extends PageInterceptor{
+    public ResponseInterceptor(SurveyRepository surveyRepository) {
+        super(surveyRepository);
+        regex = "/r/([0-9]+)";
+        surveyStatesToFilter = new HashSet<>();
+        surveyStatesToFilter.add(State.DRAFT);
+        surveyStatesToFilter.add(State.CLOSED);
+    }
+}

--- a/src/main/resources/templates/respond.html
+++ b/src/main/resources/templates/respond.html
@@ -5,6 +5,7 @@
   <title>Title</title>
 </head>
 <body>
+  <h2 th:text="${survey.getTitle()}"></h2>
 
 </body>
 </html>

--- a/src/test/java/sysc4806/project24/mini_survey_monkey/BananaMockTest.java
+++ b/src/test/java/sysc4806/project24/mini_survey_monkey/BananaMockTest.java
@@ -8,6 +8,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import sysc4806.project24.mini_survey_monkey.controllers.BananaController;
 import sysc4806.project24.mini_survey_monkey.interceptors.CollectInterceptor;
 import sysc4806.project24.mini_survey_monkey.interceptors.CreateInterceptor;
+import sysc4806.project24.mini_survey_monkey.interceptors.ResponseInterceptor;
 import sysc4806.project24.mini_survey_monkey.interceptors.SummaryInterceptor;
 
 import static org.hamcrest.Matchers.containsString;
@@ -27,6 +28,8 @@ public class BananaMockTest {
     private CreateInterceptor createInterceptor;
     @MockBean
     private CollectInterceptor collectInterceptor;
+    @MockBean
+    private ResponseInterceptor responseInterceptor;
     @MockBean
     private SummaryInterceptor summaryInterceptor;
 

--- a/src/test/java/sysc4806/project24/mini_survey_monkey/integration/ControllerIntegrationTest.java
+++ b/src/test/java/sysc4806/project24/mini_survey_monkey/integration/ControllerIntegrationTest.java
@@ -207,16 +207,32 @@ public class ControllerIntegrationTest {
                 result -> {
                     String location = result.getResponse().getHeader("Location");
                     int surveyId = Integer.parseInt(location.split("/")[2]);
+
+                    mockMvc.perform(get("/r/" + surveyId))
+                            .andExpect(status().is4xxClientError());
+
                     mockMvc.perform(post("/create/" + surveyId + "/open"))
                             .andExpect(status().is3xxRedirection())
                             .andExpect(header().string("Location", "/collect/" + surveyId));
+
                     mockMvc.perform(get("/collect/" + surveyId))
                             .andExpect(status().isOk())
                             .andExpect(view().name("collect"))
                             .andExpect(content().string(containsString("Copy this URL: ")));
-                    mockMvc.perform(get("/r/1"))
+
+                    mockMvc.perform(get("/r/" + surveyId))
                             .andExpect(status().isOk())
                             .andExpect(view().name("respond"));
+
+                    mockMvc.perform(post("/summary/" + surveyId + "/close"))
+                            .andExpect(status().is3xxRedirection());
+
+                    mockMvc.perform(get("/summary/" + surveyId))
+                            .andExpect(status().isOk())
+                            .andExpect(view().name("summary"));
+
+                    mockMvc.perform(get("/r/" + surveyId))
+                            .andExpect(status().is4xxClientError());
                 }
                 );
     }


### PR DESCRIPTION
# Description
<!-- What does this pull request do? -->
Made it so that the system will generate new survey links with r/{surveyID}"". Also added an interceptor so that respond page can only be accessed for surveys in OPEN state

## Issues
<!-- If this PR closes any issues, add them below-->
closes #24 

# How to test
<!-- How can I test this pull request request? -->

Manual test:
1. http://localhost:8080/home
2. Create a new survey
3. Click Collect Responses button
4. Copy the link displayed and paste the link into a new tab
5. Confirm that you are directed to a page with the survey title
6. Go back to home and create a new survey
7. Go to collect responses and confirm that a new sharing link with "r/2" has been generated
8. Confirm that this link works
9. Go back to collect responses page and close one of the surveys
10. Try going back to the corresponding "r/{surveyID}" page for the survey that you closed and confirm that you get an error

Integration tests:
* Run `mvn test`

# Checklist
**I've added tests**
- [x] Yes
<!-- If no, describe why -->
- [ ] No

**I've updated the DB schema and UML diagram**
- [ ] Yes
- [x] No

No changes made to either