### PR TITLE
Add survey closed page

### DIFF
--- a/src/main/java/sysc4806/project24/mini_survey_monkey/controllers/RespondController.java
+++ b/src/main/java/sysc4806/project24/mini_survey_monkey/controllers/RespondController.java
@@ -30,6 +30,10 @@ public class RespondController {
     public String respond(@PathVariable("surveyID") int surveyID, Model model) {
         Survey survey = surveyRepository.findById(surveyID);
         model.addAttribute("survey", survey);
+        if (survey.getState().equals(State.CLOSED)) {
+           return "closed";
+        }
+
         // TODO: Handle form having no questions
         ResponseForm formData = new ResponseForm();
         formData.setResponseInputs(new ArrayList<>());
@@ -47,6 +51,10 @@ public class RespondController {
     public String submit(@PathVariable("surveyID") int surveyID, @ModelAttribute ResponseForm formData) {
         List<ResponseFormInput> response = formData.getResponseInputs();
         Survey survey = surveyRepository.findById(surveyID);
+        if (survey.getState().equals(State.CLOSED)) {
+            return "redirect:/r/" + surveyID;
+        }
+
         for (int i = 0; i < response.size(); i++) {
             Question question = survey.getQuestions().get(i);
             if (question instanceof CommentQuestion) {

--- a/src/main/java/sysc4806/project24/mini_survey_monkey/interceptors/ResponseInterceptor.java
+++ b/src/main/java/sysc4806/project24/mini_survey_monkey/interceptors/ResponseInterceptor.java
@@ -19,6 +19,5 @@ public class ResponseInterceptor extends PageInterceptor{
         regex = "/r/([0-9]+)";
         surveyStatesToFilter = new HashSet<>();
         surveyStatesToFilter.add(State.DRAFT);
-        surveyStatesToFilter.add(State.CLOSED);
     }
 }

--- a/src/main/resources/templates/closed.html
+++ b/src/main/resources/templates/closed.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title th:text="|${survey.title} closed|"></title>
+</head>
+<body>
+<h2 th:text="|${survey.title} has been closed|"></h2>
+</body>
+</html>

--- a/src/test/java/sysc4806/project24/mini_survey_monkey/integration/ResponseTest.java
+++ b/src/test/java/sysc4806/project24/mini_survey_monkey/integration/ResponseTest.java
@@ -6,14 +6,10 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import static org.hamcrest.Matchers.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static sysc4806.project24.mini_survey_monkey.integration.TestHelpers.getQuestionID;
 
 @SpringBootTest
@@ -59,9 +55,11 @@ public class ResponseTest {
                     .param("responseInputs[0].responseText", "Hello world!")
             ).andExpect(status().is3xxRedirection());
 
-            // /r/1 should throw a 404 when the survey is Closed
+            // /r/1 should result in a closed survey page
             mockMvc.perform(post("/summary/" + surveyId + "/close"));
-            mockMvc.perform(get("/r/" + surveyId)).andExpect(status().is4xxClientError());
+            mockMvc.perform(get("/r/" + surveyId))
+                    .andExpect(status().isOk())
+                    .andExpect(view().name("closed"));
         });
     }
 
@@ -105,9 +103,17 @@ public class ResponseTest {
                     .param("responseInputs[1].responseText", "Hello world, 2!")
             ).andExpect(status().is3xxRedirection());
 
-            // /r/1 should throw a 404 when the survey is Closed
+            // /r/1 should result in a closed survey page
             mockMvc.perform(post("/summary/" + surveyId + "/close"));
-            mockMvc.perform(get("/r/" + surveyId)).andExpect(status().is4xxClientError());
+            mockMvc.perform(get("/r/" + surveyId))
+                    .andExpect(status().isOk())
+                    .andExpect(view().name("closed"));
+
+            // /r/1 posting should be redirect to the closed screen
+            mockMvc.perform(post("/r/" + surveyId + "/submit")
+                    .param("responseInputs[0].responseText", "Hello world!")
+                    .param("responseInputs[1].responseText", "Hello world, 2!"))
+                    .andExpect(status().is3xxRedirection());
         });
     }
 }


### PR DESCRIPTION
# Description
<!-- What does this pull request do? -->
Redirects users to a new closed page when trying to make GET or POST requests against a `/r/id` endpoint while a survey is closed.

## Issues
<!-- If this PR closes any issues, add them below-->
- #107 

# How to test
<!-- How can I test this pull request request? -->
1. Create a survey
2. Open it
3. Close it
4. Visit the collect responses page

Integration tests:
* Run `mvn test`

# Checklist
**I've added tests**
- [x] Yes
<!-- If no, describe why -->
- [ ] No

**I've updated the DB schema and UML diagram**
- [ ] Yes
- [x] No
