### PR TITLE
fix: login redirect error

### DIFF
--- a/src/main/java/sysc4806/project24/mini_survey_monkey/controllers/LoginController.java
+++ b/src/main/java/sysc4806/project24/mini_survey_monkey/controllers/LoginController.java
@@ -24,7 +24,7 @@ public class LoginController {
         return "login";
     }
 
-    @PostMapping("/login/authenticate")
+    @PostMapping("/login")
     public String authenticate(
             Model model,
             HttpServletResponse response,

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -9,7 +9,7 @@
   <body>
     <p>Don't have an account? <a href="./signup">Sign up</a></p>
 
-    <form method="post" action="/login/authenticate">
+    <form method="post" action="/login">
       <h1>Log in</h1>
       <p th:text="${error}"></p>
       <p>Enter username:</p>

--- a/src/test/java/sysc4806/project24/mini_survey_monkey/integration/IntegrationTest.java
+++ b/src/test/java/sysc4806/project24/mini_survey_monkey/integration/IntegrationTest.java
@@ -97,7 +97,7 @@ public abstract class IntegrationTest {
     }
 
     protected void loginExistingUser(User user) throws Exception {
-        mockMvc.perform(post("/login/authenticate")
+        mockMvc.perform(post("/login")
                     .param("username", user.getUsername())
                     .param("password", user.getPassword()))
             .andExpect(status().is3xxRedirection())

--- a/src/test/java/sysc4806/project24/mini_survey_monkey/integration/LoginTest.java
+++ b/src/test/java/sysc4806/project24/mini_survey_monkey/integration/LoginTest.java
@@ -28,13 +28,14 @@ public class LoginTest {
                 .param("password", password));
 
         // Should not log in user if password incorrect
-        mockMvc.perform(post("/login/authenticate")
+        mockMvc.perform(post("/login")
                 .param("username", username)
                 .param("password", "primatology3life"))
-                        .andExpect(content().string(containsString("ERROR: Invalid password.")));
+                        .andExpect(content().string(containsString("ERROR: Invalid password.")))
+                        .andExpect(status().isOk());
 
         // Should redirect to home page after successful log in
-        mockMvc.perform(post("/login/authenticate")
+        mockMvc.perform(post("/login")
                         .param("username", username)
                         .param("password", password))
                 .andExpect(status().is3xxRedirection())
@@ -46,9 +47,10 @@ public class LoginTest {
         String username = "sarvesh";
         String password = "bluelagoon";
 
-        mockMvc.perform(post("/login/authenticate")
+        mockMvc.perform(post("/login")
                         .param("username", username)
                         .param("password", password))
-                .andExpect(content().string(containsString("ERROR: Username not found.")));
+                .andExpect(content().string(containsString("ERROR: Username not found.")))
+                .andExpect(status().isOk());
     }
 }


### PR DESCRIPTION
# Description
<!-- What does this pull request do? -->
Replaces the `login/authenticate` endpoint with a POST to `login`. This fixes the redirection to `login/authenticate`.

## Issues
<!-- If this PR closes any issues, add them below-->
- closes #88 

# How to test
<!-- How can I test this pull request request? -->
Manual test:
1. Go to `/login`
2. Enter an invalid username and password
3. It should take you to `/login`, and you should see an error message

Integration tests:
* Run `mvn test`

# Checklist
**I've added tests**
- [ ] Yes
- [x] No - Updated existing tests

**I've updated the DB schema and UML diagram**
- [ ] Yes
- [x] No
