### PR TITLE
Add survey filtering by user

### DIFF
--- a/src/main/java/sysc4806/project24/mini_survey_monkey/Constant.java
+++ b/src/main/java/sysc4806/project24/mini_survey_monkey/Constant.java
@@ -4,7 +4,10 @@ public final class Constant {
 
     public static final String GUEST_USERNAME = "guest";
 
-    public final class CookieKey {
-        public static final String VALUE = "username";
+    /**
+     * Cookie values act as 'keys' in a map.
+     */
+    public final class CookieValue {
+        public static final String USERNAME = "username";
     }
 }

--- a/src/main/java/sysc4806/project24/mini_survey_monkey/Constant.java
+++ b/src/main/java/sysc4806/project24/mini_survey_monkey/Constant.java
@@ -5,6 +5,6 @@ public final class Constant {
     public static final String GUEST_USERNAME = "guest";
 
     public final class CookieKey {
-        public static final String USERNAME = "username";
+        public static final String VALUE = "username";
     }
 }

--- a/src/main/java/sysc4806/project24/mini_survey_monkey/controllers/CreateController.java
+++ b/src/main/java/sysc4806/project24/mini_survey_monkey/controllers/CreateController.java
@@ -29,7 +29,7 @@ public class CreateController {
     }
 
     @PostMapping("/create")
-    public String create(@CookieValue(value=Constant.CookieKey.VALUE, defaultValue=Constant.GUEST_USERNAME) String username) {
+    public String create(@CookieValue(value= Constant.CookieValue.USERNAME, defaultValue=Constant.GUEST_USERNAME) String username) {
         // If cookie is missing, assume that a guest is logged in.
         //
         // Check if guest is creating survey.

--- a/src/main/java/sysc4806/project24/mini_survey_monkey/controllers/CreateController.java
+++ b/src/main/java/sysc4806/project24/mini_survey_monkey/controllers/CreateController.java
@@ -29,7 +29,7 @@ public class CreateController {
     }
 
     @PostMapping("/create")
-    public String create(@CookieValue(value=Constant.CookieKey.USERNAME, defaultValue=Constant.GUEST_USERNAME) String username) {
+    public String create(@CookieValue(value=Constant.CookieKey.VALUE, defaultValue=Constant.GUEST_USERNAME) String username) {
         // If cookie is missing, assume that a guest is logged in.
         //
         // Check if guest is creating survey.

--- a/src/main/java/sysc4806/project24/mini_survey_monkey/controllers/HomeController.java
+++ b/src/main/java/sysc4806/project24/mini_survey_monkey/controllers/HomeController.java
@@ -5,28 +5,34 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import sysc4806.project24.mini_survey_monkey.Constant;
+import sysc4806.project24.mini_survey_monkey.models.User;
 import sysc4806.project24.mini_survey_monkey.repositories.SurveyRepository;
+import sysc4806.project24.mini_survey_monkey.repositories.UserRepository;
 
 @Controller
 public class HomeController {
 
-   private final SurveyRepository surveyRepository;
+    private final SurveyRepository surveyRepository;
+    private final UserRepository userRepository;
 
-    public HomeController(SurveyRepository surveyRepository) {
+    public HomeController(SurveyRepository surveyRepository, UserRepository userRepository) {
         this.surveyRepository = surveyRepository;
+        this.userRepository = userRepository;
     }
 
     @GetMapping("/")
     public String root(Model model) {
-        return "redirect:/home"; // TODO: redirect to login page once implemented
+        return "redirect:/login";
     }
 
     @GetMapping("/home")
-    public String home(
-            Model model,
-            @CookieValue(value=Constant.CookieKey.USERNAME, defaultValue=Constant.GUEST_USERNAME) String username) {
+    public String home(Model model, @CookieValue(value = Constant.CookieKey.VALUE, defaultValue =
+            Constant.GUEST_USERNAME) String username) {
         model.addAttribute("welcome", "Welcome " + username + "!");
-        model.addAttribute("surveys", surveyRepository.findAll());
+
+        User user = userRepository.findByUsername(username);
+        model.addAttribute("surveys", surveyRepository.findAllByUser(user));
+
         return "home";
     }
 }

--- a/src/main/java/sysc4806/project24/mini_survey_monkey/controllers/HomeController.java
+++ b/src/main/java/sysc4806/project24/mini_survey_monkey/controllers/HomeController.java
@@ -26,7 +26,7 @@ public class HomeController {
     }
 
     @GetMapping("/home")
-    public String home(Model model, @CookieValue(value = Constant.CookieKey.VALUE, defaultValue =
+    public String home(Model model, @CookieValue(value = Constant.CookieValue.USERNAME, defaultValue =
             Constant.GUEST_USERNAME) String username) {
         model.addAttribute("welcome", "Welcome " + username + "!");
 

--- a/src/main/java/sysc4806/project24/mini_survey_monkey/controllers/LoginController.java
+++ b/src/main/java/sysc4806/project24/mini_survey_monkey/controllers/LoginController.java
@@ -41,7 +41,7 @@ public class LoginController {
         }
 
         if (authenticated) {
-            Cookie cookie = new Cookie(Constant.CookieKey.VALUE, username);
+            Cookie cookie = new Cookie(Constant.CookieValue.USERNAME, username);
             cookie.setPath("/"); // sends cookie to specified URL and all its subdirectories
             response.addCookie(cookie);
             return "redirect:/home";

--- a/src/main/java/sysc4806/project24/mini_survey_monkey/controllers/LoginController.java
+++ b/src/main/java/sysc4806/project24/mini_survey_monkey/controllers/LoginController.java
@@ -41,7 +41,7 @@ public class LoginController {
         }
 
         if (authenticated) {
-            Cookie cookie = new Cookie(Constant.CookieKey.USERNAME, username);
+            Cookie cookie = new Cookie(Constant.CookieKey.VALUE, username);
             cookie.setPath("/"); // sends cookie to specified URL and all its subdirectories
             response.addCookie(cookie);
             return "redirect:/home";

--- a/src/main/java/sysc4806/project24/mini_survey_monkey/repositories/SurveyRepository.java
+++ b/src/main/java/sysc4806/project24/mini_survey_monkey/repositories/SurveyRepository.java
@@ -2,7 +2,11 @@ package sysc4806.project24.mini_survey_monkey.repositories;
 
 import org.springframework.data.repository.CrudRepository;
 import sysc4806.project24.mini_survey_monkey.models.Survey;
+import sysc4806.project24.mini_survey_monkey.models.User;
+
+import java.util.List;
 
 public interface SurveyRepository extends CrudRepository<Survey, Integer> {
     public Survey findById(int id);
+    public List<Survey> findAllByUser(User user);
 }

--- a/src/test/java/sysc4806/project24/mini_survey_monkey/integration/ControllerIntegrationTest.java
+++ b/src/test/java/sysc4806/project24/mini_survey_monkey/integration/ControllerIntegrationTest.java
@@ -311,8 +311,7 @@ public class ControllerIntegrationTest extends IntegrationTest {
         signUpNewUser(user2);
 
         // Create new survey and update title as user1
-        loginExistingUser(user1);
-        Cookie cookie1 = new Cookie(Constant.CookieValue.USERNAME, user1.getUsername());
+        Cookie cookie1 = loginExistingUser(user1);
 
         int surveyId = createSurvey(cookie1);
         String surveyTitle1 = "User1s survey";
@@ -322,8 +321,7 @@ public class ControllerIntegrationTest extends IntegrationTest {
         htmlContains("/home", title, cookie1);
 
         // Login as user2
-        loginExistingUser(user2);
-        Cookie cookie2 = new Cookie(Constant.CookieValue.USERNAME, user2.getUsername());
+        Cookie cookie2 = loginExistingUser(user2);
 
         // Verify that user2's home does NOT show user1's survey
         htmlContains("/home", user2.getUsername(), cookie2);

--- a/src/test/java/sysc4806/project24/mini_survey_monkey/integration/ControllerIntegrationTest.java
+++ b/src/test/java/sysc4806/project24/mini_survey_monkey/integration/ControllerIntegrationTest.java
@@ -286,7 +286,7 @@ public class ControllerIntegrationTest extends IntegrationTest {
         user.setPassword("i<3braeden");
         signUpNewUser(user);
         loginExistingUser(user);
-        Cookie cookie = new Cookie(Constant.CookieKey.VALUE, user.getUsername());
+        Cookie cookie = new Cookie(Constant.CookieValue.USERNAME, user.getUsername());
 
         // Create new survey and update title as logged-in user
         int surveyId = createSurvey(cookie);
@@ -312,7 +312,7 @@ public class ControllerIntegrationTest extends IntegrationTest {
 
         // Create new survey and update title as user1
         loginExistingUser(user1);
-        Cookie cookie1 = new Cookie(Constant.CookieKey.VALUE, user1.getUsername());
+        Cookie cookie1 = new Cookie(Constant.CookieValue.USERNAME, user1.getUsername());
 
         int surveyId = createSurvey(cookie1);
         String surveyTitle1 = "User1s survey";
@@ -323,7 +323,7 @@ public class ControllerIntegrationTest extends IntegrationTest {
 
         // Login as user2
         loginExistingUser(user2);
-        Cookie cookie2 = new Cookie(Constant.CookieKey.VALUE, user2.getUsername());
+        Cookie cookie2 = new Cookie(Constant.CookieValue.USERNAME, user2.getUsername());
 
         // Verify that user2's home does NOT show user1's survey
         htmlContains("/home", user2.getUsername(), cookie2);

--- a/src/test/java/sysc4806/project24/mini_survey_monkey/integration/ControllerIntegrationTest.java
+++ b/src/test/java/sysc4806/project24/mini_survey_monkey/integration/ControllerIntegrationTest.java
@@ -314,8 +314,7 @@ public class ControllerIntegrationTest extends IntegrationTest {
         Cookie cookie1 = loginExistingUser(user1);
 
         int surveyId = createSurvey(cookie1);
-        String surveyTitle1 = "User1s survey";
-        String title = updateSurveyTitle(surveyId, surveyTitle1, cookie1);
+        String title = updateSurveyTitle(surveyId, null, cookie1);
 
         htmlContains("/home", user1.getUsername(), cookie1);
         htmlContains("/home", title, cookie1);

--- a/src/test/java/sysc4806/project24/mini_survey_monkey/integration/IntegrationTest.java
+++ b/src/test/java/sysc4806/project24/mini_survey_monkey/integration/IntegrationTest.java
@@ -94,6 +94,14 @@ public abstract class IntegrationTest {
                 .andExpect(content().string(containsString(text)));
     }
 
+    /**
+     * Checks if the HTML does not contain a specified text.
+     *
+     * @param urlTemplate URL to GET HTML from. (Eg. "/home", "/create/1")
+     * @param text Text to search for.
+     * @param cookie Cookie to use in request. If null, generates a default cookie.
+     * @throws Exception When html does contain the text.
+     */
     protected void htmlNotContains(String urlTemplate, String text, Cookie cookie) throws Exception {
         if (cookie == null) { cookie = createDefaultCookie();}
 

--- a/src/test/java/sysc4806/project24/mini_survey_monkey/integration/IntegrationTest.java
+++ b/src/test/java/sysc4806/project24/mini_survey_monkey/integration/IntegrationTest.java
@@ -11,10 +11,10 @@ import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -29,7 +29,9 @@ public abstract class IntegrationTest {
      * @return ID of created survey.
      * @throws Exception
      */
-    protected int createSurvey() throws Exception {
+    protected int createSurvey(Cookie cookie) throws Exception {
+        if (cookie == null) { cookie = createDefaultCookie();}
+
         // AtomicInteger allows a variable to be set and returned from a lambda expression.
         //
         // Typically, AtomicInteger is used for counters and should not be used to replace
@@ -39,7 +41,7 @@ public abstract class IntegrationTest {
         // @author Braeden
         AtomicInteger surveyId = new AtomicInteger();
 
-        mockMvc.perform(post("/create")).andDo(
+        mockMvc.perform(post("/create").cookie(cookie)).andDo(
                 result -> {
                     String location = result.getResponse().getHeader("Location");
                     surveyId.set(Integer.parseInt(location.split("/")[2]));
@@ -57,7 +59,8 @@ public abstract class IntegrationTest {
      * @return Title of updated survey.
      * @throws Exception
      */
-    protected String updateSurveyTitle(int surveyId, String title) throws Exception {
+    protected String updateSurveyTitle(int surveyId, String title, Cookie cookie) throws Exception {
+        if (cookie == null) { cookie = createDefaultCookie();}
         String newTitle = title;
 
         if (title == null) {
@@ -66,7 +69,8 @@ public abstract class IntegrationTest {
         }
 
         mockMvc.perform(post("/create/" + surveyId + "/update")
-                        .param("title", newTitle))
+                        .param("title", newTitle)
+                        .cookie(cookie))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(header().string("Location", "/create/" + surveyId));
 
@@ -84,10 +88,19 @@ public abstract class IntegrationTest {
     protected void htmlContains(String urlTemplate, String text, Cookie cookie) throws Exception {
         if (cookie == null) { cookie = createDefaultCookie();}
 
-        mockMvc.perform(get("/home")
+        mockMvc.perform(get(urlTemplate)
                         .cookie(cookie))
                 .andExpect(status().isOk())
                 .andExpect(content().string(containsString(text)));
+    }
+
+    protected void htmlNotContains(String urlTemplate, String text, Cookie cookie) throws Exception {
+        if (cookie == null) { cookie = createDefaultCookie();}
+
+        mockMvc.perform(get(urlTemplate)
+                        .cookie(cookie))
+                .andExpect(status().isOk())
+                .andExpect(content().string(not(containsString(text))));
     }
 
     protected void signUpNewUser(User user) throws Exception {

--- a/src/test/java/sysc4806/project24/mini_survey_monkey/integration/IntegrationTest.java
+++ b/src/test/java/sysc4806/project24/mini_survey_monkey/integration/IntegrationTest.java
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
+import sysc4806.project24.mini_survey_monkey.Constant;
 import sysc4806.project24.mini_survey_monkey.models.User;
 
 import java.util.Random;
@@ -117,12 +118,24 @@ public abstract class IntegrationTest {
                 .param("password", user.getPassword()));
     }
 
-    protected void loginExistingUser(User user) throws Exception {
+    /**
+     * Logs existing user into system.
+     *
+     * @param user Existing user to log in.
+     * @return Cookie of user.
+     * @throws Exception
+     */
+    protected Cookie loginExistingUser(User user) throws Exception {
         mockMvc.perform(post("/login")
                     .param("username", user.getUsername())
                     .param("password", user.getPassword()))
             .andExpect(status().is3xxRedirection())
-            .andExpect(header().string("Location", "/home"));}
+            .andExpect(header().string("Location", "/home"));
+
+        // Successful login
+        return new Cookie(Constant.CookieValue.USERNAME, user.getUsername());
+    }
+
 
     private Cookie createDefaultCookie() {
         return new Cookie("JSESSIONID", "");


### PR DESCRIPTION
# Description
<!-- What does this pull request do? -->
When a user visits their `/home` page, they only see surveys they've created.

- **NOTE: This should only be merged after #88** 

## Issues
<!-- If this PR closes any issues, add them below-->
- closes #101 

# How to test
<!-- How can I test this pull request request? -->
Manual test:
1. Create two users, user1 and user2
2. Create a survey with user1
3. Login to user2 - you shouldn't be able to see user1's survey

Integration tests:
* Run `mvn test`

# Checklist
**I've added tests**
- [x] Yes
- [ ] No

**I've updated the DB schema and UML diagram**
- [ ] Yes
- [x] No
