### PR TITLE
Add scale question to respond page

### DIFF
--- a/src/main/java/sysc4806/project24/mini_survey_monkey/ResponseFormInput.java
+++ b/src/main/java/sysc4806/project24/mini_survey_monkey/ResponseFormInput.java
@@ -1,11 +1,9 @@
 package sysc4806.project24.mini_survey_monkey;
 
-import jakarta.persistence.criteria.CriteriaBuilder;
-
 public final class ResponseFormInput {
     private String responseText;
 
-    private Integer responseScaleSelection;
+    private int selectedValue;
 
     public String getResponseText() {
         return responseText;
@@ -15,12 +13,12 @@ public final class ResponseFormInput {
         this.responseText = responseText;
     }
 
-    public Integer getResponseScaleSelection() {
-        return responseScaleSelection;
+    public int getSelectedValue() {
+        return selectedValue;
     }
 
-    public void setResponseScaleSelection(Integer responseScaleSelection) {
-        this.responseScaleSelection = responseScaleSelection;
+    public void setSelectedValue(int responseScaleSelection) {
+        this.selectedValue = responseScaleSelection;
     }
 }
 

--- a/src/main/java/sysc4806/project24/mini_survey_monkey/ResponseFormInput.java
+++ b/src/main/java/sysc4806/project24/mini_survey_monkey/ResponseFormInput.java
@@ -1,7 +1,11 @@
 package sysc4806.project24.mini_survey_monkey;
 
+import jakarta.persistence.criteria.CriteriaBuilder;
+
 public final class ResponseFormInput {
     private String responseText;
+
+    private Integer responseScaleSelection;
 
     public String getResponseText() {
         return responseText;
@@ -11,5 +15,12 @@ public final class ResponseFormInput {
         this.responseText = responseText;
     }
 
+    public Integer getResponseScaleSelection() {
+        return responseScaleSelection;
+    }
+
+    public void setResponseScaleSelection(Integer responseScaleSelection) {
+        this.responseScaleSelection = responseScaleSelection;
+    }
 }
 

--- a/src/main/java/sysc4806/project24/mini_survey_monkey/controllers/RespondController.java
+++ b/src/main/java/sysc4806/project24/mini_survey_monkey/controllers/RespondController.java
@@ -68,11 +68,8 @@ public class RespondController {
                 } else if (question instanceof ScaleQuestion) {
                     ScaleResponse scaleResponse = new ScaleResponse();
                     Integer responseValue = response.get(i).getSelectedValue();
-                    System.out.println(responseValue);
                     scaleResponse.setSelectedValue(responseValue);
                     question.getResponses().add(scaleResponse);
-                    System.out.println(question.getResponses());
-                    System.out.println(question.getResponses().size());
                 } else {
                     throw new RuntimeException("Unhandled question type: " + question.getClass());
                 }

--- a/src/main/java/sysc4806/project24/mini_survey_monkey/controllers/RespondController.java
+++ b/src/main/java/sysc4806/project24/mini_survey_monkey/controllers/RespondController.java
@@ -55,25 +55,30 @@ public class RespondController {
             return "redirect:/r/" + surveyID;
         }
 
-        for (int i = 0; i < response.size(); i++) {
-            Question question = survey.getQuestions().get(i);
-            if (question instanceof CommentQuestion) {
-                CommentResponse commentResponse = new CommentResponse();
-                commentResponse.setText(response.get(i).getResponseText());
-                question.getResponses().add(commentResponse);
-            } else if (question instanceof MultipleChoiceQuestion) {
-                // TODO: Implement
-                continue;
-            } else if (question instanceof ScaleQuestion) {
-                ScaleResponse scaleResponse = new ScaleResponse();
-                scaleResponse.setSelectedValue(response.get(i).getResponseScaleSelection());
-                question.getResponses().add(scaleResponse);
-                continue;
-            } else {
-                throw new RuntimeException("Unhandled question type: " + question.getClass());
-            }
+        if (response != null){
+            for (int i = 0; i < response.size(); i++) {
+                Question question = survey.getQuestions().get(i);
+                if (question instanceof CommentQuestion) {
+                    CommentResponse commentResponse = new CommentResponse();
+                    commentResponse.setText(response.get(i).getResponseText());
+                    question.getResponses().add(commentResponse);
+                } else if (question instanceof MultipleChoiceQuestion) {
+                    // TODO: Implement
+                    continue;
+                } else if (question instanceof ScaleQuestion) {
+                    ScaleResponse scaleResponse = new ScaleResponse();
+                    Integer responseValue = response.get(i).getSelectedValue();
+                    System.out.println(responseValue);
+                    scaleResponse.setSelectedValue(responseValue);
+                    question.getResponses().add(scaleResponse);
+                    System.out.println(question.getResponses());
+                    System.out.println(question.getResponses().size());
+                } else {
+                    throw new RuntimeException("Unhandled question type: " + question.getClass());
+                }
 
-            questionRepository.save(question);
+                questionRepository.save(question);
+            }
         }
 
         return "redirect:/r/" + surveyID;

--- a/src/main/java/sysc4806/project24/mini_survey_monkey/controllers/RespondController.java
+++ b/src/main/java/sysc4806/project24/mini_survey_monkey/controllers/RespondController.java
@@ -62,10 +62,12 @@ public class RespondController {
                 commentResponse.setText(response.get(i).getResponseText());
                 question.getResponses().add(commentResponse);
             } else if (question instanceof MultipleChoiceQuestion) {
-               // TODO: Implement
+                // TODO: Implement
                 continue;
             } else if (question instanceof ScaleQuestion) {
-                // TODO: Implement
+                ScaleResponse scaleResponse = new ScaleResponse();
+                scaleResponse.setSelectedValue(response.get(i).getResponseScaleSelection());
+                question.getResponses().add(scaleResponse);
                 continue;
             } else {
                 throw new RuntimeException("Unhandled question type: " + question.getClass());

--- a/src/main/resources/templates/respond.html
+++ b/src/main/resources/templates/respond.html
@@ -21,7 +21,7 @@
                         <span th:text="${question.minValue}">1</span>
                         <div style="flex-grow: 1; display: flex; justify-content: space-evenly;">
                             <input type="radio" th:id="'scale-' + ${question.id} + '-' + ${i}"
-                                   th:field="*{responseInputs[__${inputStat.index}__].responseScaleSelection}"
+                                   th:field="*{responseInputs[__${inputStat.index}__].selectedValue}"
                                    th:name="'scale-' + ${question.id}" th:value="${i}"
                                    th:each="i : ${#numbers.sequence(question.minValue, question.maxValue)}">
                         </div>

--- a/src/main/resources/templates/respond.html
+++ b/src/main/resources/templates/respond.html
@@ -16,6 +16,18 @@
                 <div th:case="'CommentQuestion'">
                     <input th:field="*{responseInputs[__${inputStat.index}__].responseText}" type="text">
                 </div>
+                <div th:case="'ScaleQuestion'">
+                    <div style="display: flex; justify-content: space-between; width: 100%;">
+                        <span th:text="${question.minValue}">1</span>
+                        <div style="flex-grow: 1; display: flex; justify-content: space-evenly;">
+                            <input type="radio" th:id="'scale-' + ${question.id} + '-' + ${i}"
+                                   th:field="*{responseInputs[__${inputStat.index}__].responseScaleSelection}"
+                                   th:name="'scale-' + ${question.id}" th:value="${i}"
+                                   th:each="i : ${#numbers.sequence(question.minValue, question.maxValue)}">
+                        </div>
+                        <span th:text="${question.maxValue}">10</span>
+                    </div>
+                </div>
                 <div th:case="*">
                     <p th:text="|Unhandled question type: ${question.class.simpleName}|">
                 </div>

--- a/src/main/resources/templates/summary.html
+++ b/src/main/resources/templates/summary.html
@@ -30,6 +30,14 @@
                         </li>
                     </ul>
                 </div>
+                <div th:if="${#strings.equals(question.class.simpleName, 'ScaleQuestion')}">
+                    <h4>Responses:</h4>
+                    <ul>
+                        <li th:each="response : ${question.responses}" th:text="${response.selectedValue}">
+                            <!-- Display each response -->
+                        </li>
+                    </ul>
+                </div>
             </li>
         </ol>
 


### PR DESCRIPTION
# Description
<!-- What does this pull request do? -->
Displays scale questions on the respond page. User can see the responses as a list of responses.
Future a PR will display the responses as a histogram on the summary page

## Issues
<!-- If this PR closes any issues, add them below-->
closes #111 

# How to test
<!-- How can I test this pull request request? -->

Manual Test:
1. Go to localhost:8080
2. Create a new survey with 1+ scale questions and hit collect responses
3. Go to the respond page and confirm that the questions are there
4. Fill in the responses and click submit, repeat a couple times
5. Go to the summary page and confirm that the responses are displayed on the summary page

Integration tests:
* Run `mvn test`

# Checklist
**I've added tests**
- [x] Yes
<!-- If no, describe why -->
- [ ] No

**I've updated the DB schema and UML diagram**
- [ ] Yes
- [x] No - Didn't change an models